### PR TITLE
Add a default style to themes which gets applied to "everything else".

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,19 @@ Detailed API documenation can be found [here](http://cli-highlight.surge.sh/).
 
 ## Themes
 You can write your own theme in a JSON file and pass it with `--theme`.
-The key must be one of the [highlight.js CSS class names](http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html)
+The key must be one of the [highlight.js CSS class names](http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html) or `"default"`,
 and the value must be one or an array of [Chalk styles](https://github.com/chalk/chalk#styles) to be applied to that token.
 
 ```json
 {
   "keyword": "blue",
   "built_in": ["cyan", "dim"],
-  "string": "red"
+  "string": "red",
+  "default": "gray"
 }
 ```
+
+The style for `"default"` will be applied to any substrings not handled by highlight.js. The specifics depend on the language but this typically includes things like commas in parameter lists, semicolons at the end of lines, etc.
 
 The theme is combined with the [default theme](http://cli-highlight.surge.sh/globals.html#default_theme).
 The default theme is still not colored a lot or optimized for many languages, PRs welcome!

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,22 @@ import * as hljs from 'highlight.js'
 import * as parse5 from 'parse5'
 import { DEFAULT_THEME, plain, Theme } from './theme'
 
-function colorizeNode(node: parse5.AST.HtmlParser2.Node, theme: Theme = {}): string {
+function colorizeNode(node: parse5.AST.HtmlParser2.Node, theme: Theme = {}, context?: string): string {
     switch (node.type) {
         case 'text': {
-            return (node as parse5.AST.HtmlParser2.TextNode).data
+            const text = (node as parse5.AST.HtmlParser2.TextNode).data
+            if (context === undefined) {
+                return (theme.default || DEFAULT_THEME.default || plain)(text)
+            } else {
+                return text
+            }
         }
         case 'tag': {
             const hljsClass = /hljs-(\w+)/.exec((node as parse5.AST.HtmlParser2.Element).attribs.class)
             if (hljsClass) {
                 const token = hljsClass[1]
                 const nodeData = (node as parse5.AST.HtmlParser2.Element).childNodes
-                    .map(node => colorizeNode(node, theme))
+                    .map(node => colorizeNode(node, theme, token))
                     .join('')
                 return ((theme as any)[token] || (DEFAULT_THEME as any)[token] || plain)(nodeData)
             }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -280,7 +280,12 @@ export interface JsonTheme extends Tokens<Style | Style[]> {}
  * };
  * ```
  */
-export interface Theme extends Tokens<(codePart: string) => string> {}
+export interface Theme extends Tokens<(codePart: string) => string> {
+    /**
+     * things not matched by any token
+     */
+    default?: (codePart: string) => string
+}
 
 /**
  * Identity function for tokens that should not be styled (returns the input string as-is).
@@ -498,6 +503,11 @@ export const DEFAULT_THEME: Theme = {
      * deleted line in a diff
      */
     deletion: chalk.red,
+
+    /**
+     * things not matched by any token
+     */
+    default: plain,
 }
 
 /**


### PR DESCRIPTION
The new `default` key in themes allows configuring the "base" style for substrings not handled by highlight.js. The specifics depend on the language but this typically includes things like commas in parameter lists, semicolons at the end of lines, etc.

For example, here's how the JSON fixture looks in my console with no styles set:

<img width="461" alt="screen shot 2019-03-03 at 11 33 59 am" src="https://user-images.githubusercontent.com/35091/53700531-603e3380-3da8-11e9-90ad-681740ebb619.png">

And here it is with `default` set to `dim`:

<img width="461" alt="screen shot 2019-03-03 at 11 32 42 am" src="https://user-images.githubusercontent.com/35091/53700539-6b915f00-3da8-11e9-8f22-d5ea9f291b21.png">
