### PR TITLE
Upgrade to Chalk 4, Node >= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-  - '8'
   - '10'
+  - '12'
+  - '14'
 
 env:
   global:
@@ -30,7 +31,7 @@ after_success:
 jobs:
   include:
     - stage: release
-      node_js: '8'
+      node_js: '10'
       script:
         - npm run build
         - npm run semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -2297,9 +2297,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "highlight": "./bin/highlight"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=10.0.0",
     "npm": ">=5.0.0"
   },
   "scripts": {
@@ -78,7 +78,7 @@
   },
   "homepage": "https://github.com/felixfbecker/cli-highlight#readme",
   "dependencies": {
-    "chalk": "^3.0.0",
+    "chalk": "^4.0.0",
     "highlight.js": "^9.6.0",
     "mz": "^2.4.0",
     "parse5": "^5.1.1",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,7 @@
 import { Chalk, default as _chalk, Level } from 'chalk'
 
 // Always enable at least basic color support, even if not auto-detected
-const chalk = new _chalk.Instance({ level: Math.min(_chalk.level, Level.Basic) })
+const chalk = new _chalk.Instance({ level: Math.min(_chalk.level, 1) as Level })
 
 /**
  * A generic interface that holds all available language tokens.


### PR DESCRIPTION
Upgrade to Chalk version 4. This version deals with a Node option to remove __proto__ (<https://nodejs.org/api/cli.html#cli_disable_proto_mode>).

I've also removed support for node 8 since it's EOL and added 12 (current LTS) and 14 (current active) to the test matrix.