### PR TITLE
fix: minimum detected chalk level

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,7 @@
 import { Chalk, default as _chalk, Level } from 'chalk'
 
 // Always enable at least basic color support, even if not auto-detected
-const chalk = new _chalk.Instance({ level: Math.min(_chalk.level, Level.Basic) })
+const chalk = new _chalk.Instance({ level: Math.max(_chalk.level, Level.Basic) })
 
 /**
  * A generic interface that holds all available language tokens.


### PR DESCRIPTION
Shouldn't this line be `Math.max` instead of `Math.min` if we want to support a minimum level? The way it is now, `Level.Basic` never gets applied if chalk detects a `level` of `0` since `Math.min(0, 1) === 0`